### PR TITLE
SDK v2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "C_Cpp.default.defines": [
+        "DM_PLATFORM_HTML5"
+    ]
+}

--- a/crazygames/lib/web/lib_crazysdk.js
+++ b/crazygames/lib/web/lib_crazysdk.js
@@ -3,55 +3,55 @@
 var LibCrazyGamesSdk = {
 
     CrazyGamesSdkJs_init: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance(); //Getting the SDK
-        crazysdk.sdkGameLoadingStop(); //Initializing the SDK, call as early as possible
+        window.CrazyGames.SDK.game.sdkGameLoadingStop();
     },
 
-    CrazyGamesSdkJs_initListeners: function () {
-        window.crazysdk_jstodef_listeners = {
-            adStarted: function () {
-                JsToDef.send("CrazyGame_adStared");
-            },
-            adFinished: function () {
-                JsToDef.send("CrazyGame_adFinished");
-            },
-            adError: function () {
-                JsToDef.send("CrazyGame_adError");
-            }
-        }
-    },
+    // CrazyGamesSdkJs_initListeners: function () {
+    //     window.crazysdk_jstodef_listeners = {
+    //         adStarted: function () {
+    //             JsToDef.send("CrazyGame_adStared");
+    //         },
+    //         adFinished: function () {
+    //             JsToDef.send("CrazyGame_adFinished");
+    //         },
+    //         adError: function () {
+    //             JsToDef.send("CrazyGame_adError");
+    //         }
+    //     }
+    // },
 
     CrazyGamesSdkJs_requestAd: function (type) {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        var type_string = UTF8ToString(type);
-        crazysdk.requestAd(type_string);
+        const type_string = UTF8ToString(type);
+        const callbacks = {
+            adFinished: () => JsToDef.send("CrazyGame_adFinished"),
+            adError: (error) => JsToDef.send("CrazyGame_adError", error),
+            adStarted: () => JsToDef.send("CrazyGame_adStared"),
+        };
+        window.CrazyGames.SDK.ad.requestAd(type_string, callbacks);
     },
 
-    CrazyGamesSdkJs_addEventListeners: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        crazysdk.addEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
-        crazysdk.addEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
-        crazysdk.addEventListener('adError', window.crazysdk_jstodef_listeners.adError);
-    },
-    CrazyGamesSdkJs_clearEventListeners: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        crazysdk.removeEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
-        crazysdk.removeEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
-        crazysdk.removeEventListener('adError', window.crazysdk_jstodef_listeners.adError);
-    },
+    // CrazyGamesSdkJs_addEventListeners: function () {
+    //     const crazysdk = window.CrazyGames.CrazySDK.getInstance();
+    //     crazysdk.addEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
+    //     crazysdk.addEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
+    //     crazysdk.addEventListener('adError', window.crazysdk_jstodef_listeners.adError);
+    // },
+    // CrazyGamesSdkJs_clearEventListeners: function () {
+    //     const crazysdk = window.CrazyGames.CrazySDK.getInstance();
+    //     crazysdk.removeEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
+    //     crazysdk.removeEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
+    //     crazysdk.removeEventListener('adError', window.crazysdk_jstodef_listeners.adError);
+    // },
 
     CrazyGamesSdkJs_gameplayStart: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        crazysdk.gameplayStart()
+        window.CrazyGames.SDK.game.gameplayStart();
     },
 
     CrazyGamesSdkJs_gameplayStop: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        crazysdk.gameplayStop()
+        window.CrazyGames.SDK.game.gameplayStop();
     },
     CrazyGamesSdkJs_happyTime: function () {
-        const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-        crazysdk.happytime()
+        window.CrazyGames.SDK.game.happytime();
     }
 
 

--- a/crazygames/lib/web/lib_crazysdk.js
+++ b/crazygames/lib/web/lib_crazysdk.js
@@ -2,23 +2,9 @@
 
 var LibCrazyGamesSdk = {
 
-    CrazyGamesSdkJs_init: function () {
+    CrazyGamesSdkJs_gameLoadingStop: function () {
         window.CrazyGames.SDK.game.sdkGameLoadingStop();
     },
-
-    // CrazyGamesSdkJs_initListeners: function () {
-    //     window.crazysdk_jstodef_listeners = {
-    //         adStarted: function () {
-    //             JsToDef.send("CrazyGame_adStared");
-    //         },
-    //         adFinished: function () {
-    //             JsToDef.send("CrazyGame_adFinished");
-    //         },
-    //         adError: function () {
-    //             JsToDef.send("CrazyGame_adError");
-    //         }
-    //     }
-    // },
 
     CrazyGamesSdkJs_requestAd: function (type) {
         const type_string = UTF8ToString(type);
@@ -30,19 +16,6 @@ var LibCrazyGamesSdk = {
         window.CrazyGames.SDK.ad.requestAd(type_string, callbacks);
     },
 
-    // CrazyGamesSdkJs_addEventListeners: function () {
-    //     const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-    //     crazysdk.addEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
-    //     crazysdk.addEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
-    //     crazysdk.addEventListener('adError', window.crazysdk_jstodef_listeners.adError);
-    // },
-    // CrazyGamesSdkJs_clearEventListeners: function () {
-    //     const crazysdk = window.CrazyGames.CrazySDK.getInstance();
-    //     crazysdk.removeEventListener('adStarted', window.crazysdk_jstodef_listeners.adStarted);
-    //     crazysdk.removeEventListener('adFinished', window.crazysdk_jstodef_listeners.adFinished);
-    //     crazysdk.removeEventListener('adError', window.crazysdk_jstodef_listeners.adError);
-    // },
-
     CrazyGamesSdkJs_gameplayStart: function () {
         window.CrazyGames.SDK.game.gameplayStart();
     },
@@ -50,10 +23,10 @@ var LibCrazyGamesSdk = {
     CrazyGamesSdkJs_gameplayStop: function () {
         window.CrazyGames.SDK.game.gameplayStop();
     },
+
     CrazyGamesSdkJs_happyTime: function () {
         window.CrazyGames.SDK.game.happytime();
     }
-
 
 }
 

--- a/crazygames/manifests/web/engine_template.html
+++ b/crazygames/manifests/web/engine_template.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <head>
-	<script src="https://sdk.crazygames.com/crazygames-sdk-v1.js"></script>
+	<script src="https://sdk.crazygames.com/crazygames-sdk-v2.js"></script>
 	<script>
-		const crazysdk = window.CrazyGames.CrazySDK.getInstance(); //Getting the SDK
-		crazysdk.init(); //Initializing the SDK, call as early as possible
-		crazysdk.sdkGameLoadingStart();
+		window.CrazyGames.SDK.game.sdkGameLoadingStart();
 	</script>
 </head>
 

--- a/crazygames/src/crazysdk.cpp
+++ b/crazygames/src/crazysdk.cpp
@@ -8,45 +8,23 @@
 
 
 extern "C" {
-    void CrazyGamesSdkJs_init();
+    void CrazyGamesSdkJs_gameLoadingStop();
     void CrazyGamesSdkJs_requestAd(const char* type);
-    void CrazyGamesSdkJs_initListeners();
-    void CrazyGamesSdkJs_addEventListeners();
-    void CrazyGamesSdkJs_clearEventListeners();
     void CrazyGamesSdkJs_gameplayStart();
     void CrazyGamesSdkJs_gameplayStop();
     void CrazyGamesSdkJs_happyTime();
 }
 
-static int CrazyGamesSdkJs_initLua(lua_State* L){
+static int CrazyGamesSdkJs_gameLoadingStopLua(lua_State* L){
     DM_LUA_STACK_CHECK(L, 0);
-    CrazyGamesSdkJs_init();
+    CrazyGamesSdkJs_gameLoadingStop();
     return 0;
 }
-
-
 
 static int CrazyGamesSdkJs_requestAdLua(lua_State* L){
     DM_LUA_STACK_CHECK(L, 0);
     const char* type = luaL_checkstring(L, 1);
     CrazyGamesSdkJs_requestAd(type);
-    return 0;
-}
-
-static int CrazyGamesSdkJs_initListenersLua(lua_State* L){
-    DM_LUA_STACK_CHECK(L, 0);
-    CrazyGamesSdkJs_initListeners();
-    return 0;
-}
-
-static int CrazyGamesSdkJs_addEventListenersLua(lua_State* L){
-    DM_LUA_STACK_CHECK(L, 0);
-    CrazyGamesSdkJs_addEventListeners();
-    return 0;
-}
-static int CrazyGamesSdkJs_clearEventListenersLua(lua_State* L){
-    DM_LUA_STACK_CHECK(L, 0);
-    CrazyGamesSdkJs_clearEventListeners();
     return 0;
 }
 
@@ -71,11 +49,8 @@ static int CrazyGamesSdkJs_happyTimeLua(lua_State* L){
 // Functions exposed to Lua
 static const luaL_reg Module_methods[] =
 {
-    {"init", CrazyGamesSdkJs_initLua},
+    {"game_loading_stop", CrazyGamesSdkJs_gameLoadingStopLua},
     {"request_ad", CrazyGamesSdkJs_requestAdLua},
-    {"init_listeners", CrazyGamesSdkJs_initListenersLua},
-    {"add_event_listeners", CrazyGamesSdkJs_addEventListenersLua},
-    {"clear_event_listeners", CrazyGamesSdkJs_clearEventListenersLua},
     {"gameplay_stop", CrazyGamesSdkJs_gameplayStopLua},
     {"gameplay_start", CrazyGamesSdkJs_gameplayStartLua},
     {"happy_time", CrazyGamesSdkJs_happyTimeLua},


### PR DESCRIPTION
This repo is currently using the outdated [v1](https://docs.crazygames.com/sdk/html5/) SDK. This PR makes it compatible with [v2](https://docs.crazygames.com/sdk/html5-v2/).

The main difference is you no longer have to initialise the SDK and there are no listeners.

If this is merged in I can work on improving this more to include the missing functions.

It would also seem better to handle the game loading calls in the html like how the [Poki SDK](https://github.com/AGulev/defold-poki-sdk/blob/main/poki-sdk/manifests/web/engine_template.html#L11-L19) does it. It might also be possible to pass Lua functions as callbacks for the requests and eliminate the need for JsToDef.